### PR TITLE
Define `tile` so it can be overloaded

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MapBroadcast"
 uuid = "ebd9b9da-f48d-417c-9660-449667d60261"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/MapBroadcast.jl
+++ b/src/MapBroadcast.jl
@@ -98,7 +98,7 @@ function promote_shape(ax, args::AbstractArray...)
   return promote_shape_tile(ax, args...)
 end
 function promote_shape_tile(common_axes, args::AbstractArray...)
-  return map(arg -> tile_to_shape(arg, common_axes), args)
+  return map(arg -> tile(arg, common_axes), args)
 end
 
 using BlockArrays: mortar
@@ -110,8 +110,9 @@ function extend(t::Tuple, value, length)
 end
 
 # Handles logic of expanding singleton dimensions
-# to match an array shape in broadcasting.
-function tile_to_shape(a::AbstractArray, ax)
+# to match an array shape in broadcasting
+# by tiling or repeating the input array.
+function tile(a::AbstractArray, ax)
   axes(a) == ax && return a
   # Must be one-based for now.
   @assert all(isone, first.(ax))


### PR DESCRIPTION
Simplify the name `tile_to_shape` to `tile`. The idea will be to make it part of the publicly overloadable API, so we can overload it for named dims arrays (it would probably be tough to make the current definition generic enough for that case, since the dimensions of the inputs could be unaligned).